### PR TITLE
Fix encoding of X11GetKeyboardMappingRequest

### DIFF
--- a/lib/src/x11_requests.dart
+++ b/lib/src/x11_requests.dart
@@ -6065,16 +6065,18 @@ class X11GetKeyboardMappingRequest extends X11Request {
 
   factory X11GetKeyboardMappingRequest.fromBuffer(X11ReadBuffer buffer) {
     buffer.skip(1);
-    var firstKeycode = buffer.readUint32();
+    var firstKeycode = buffer.readUint8();
     var count = buffer.readUint8();
+    buffer.skip(2);
     return X11GetKeyboardMappingRequest(firstKeycode, count);
   }
 
   @override
   void encode(X11WriteBuffer buffer) {
     buffer.skip(1);
-    buffer.writeUint32(firstKeycode);
+    buffer.writeUint8(firstKeycode);
     buffer.writeUint8(count);
+    buffer.skip(2);
   }
 
   @override


### PR DESCRIPTION
Minimum repro:

```dart
import 'package:x11/x11.dart';

void main() async {
  var client = X11Client();
  await client.connect();

  final mapping = await client.getKeyboardMapping(firstKeycode: 100, count: 1);
  print(mapping);

  await client.close();
}
```

Correct encoding of `X11GetKeyboardMappingRequest` borrowed from `python-xlib` [here](https://github.com/python-xlib/python-xlib/blob/4e8bbf8fc4941e5da301a8b3db8d27e98de68666/Xlib/protocol/request.py#L1506).
